### PR TITLE
Feature/use GitHub actions

### DIFF
--- a/.github/bootstrap.patch
+++ b/.github/bootstrap.patch
@@ -10,7 +10,7 @@ index 2be126e..42e2350 100644
 -    url: https://github.com/AdaCore/OpenUxAS.git
 -    revision: ada
 +    vcs: external
-+    url: /home/runner/work/OpenUxAS/OpenUxAS
++    url: $GITHUB_WORKSPACE
 +    revision: None
  amase:
      vcs: git

--- a/.github/bootstrap.patch
+++ b/.github/bootstrap.patch
@@ -1,0 +1,17 @@
+diff --git specs/config/repositories.yaml specs/config/repositories.yaml
+index 2be126e..42e2350 100644
+--- specs/config/repositories.yaml
++++ specs/config/repositories.yaml
+@@ -31,9 +31,9 @@ lmcpgen:
+     url: https://github.com/AdaCore/LmcpGen.git
+     revision: ada
+ openuxas:
+-    vcs: git
+-    url: https://github.com/AdaCore/OpenUxAS.git
+-    revision: ada
++    vcs: external
++    url: /home/runner/work/OpenUxAS/OpenUxAS
++    revision: None
+ amase:
+     vcs: git
+     url: https://github.com/afrl-rq/OpenAMASE.git

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel zmq e3-core e3-testsuite
+          sudo apt install -y uuid-dev
 
       - name: Build with anod
         run: SHELL=/bin/bash bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -1,0 +1,33 @@
+on: [push, pull_request]
+name: Build UxAS
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        component: [uxas]
+        qualifier: [dev, scenario=gcov]
+        python-version: [3.8]
+    runs-on: ${{ matrix.os }}
+    name: Build
+    steps:
+      - name: Check out OpenUxAS-bootstrap
+        uses: actions/checkout@v2
+        with:
+          repository: AdaCore/OpenUxAS-bootstrap
+          path: bootstrap
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel zmq e3-core e3-testsuite
+      - name: Build with anod
+        run: bootstrap/anod build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+      - name: Set environment
+        run: eval "$( bootstrap/anod printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+      - name: Run tests
+        run: testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Patch bootstrap
         run: |
-          patch -d$HOME/bootstrap -p0 < $GITHUB_WORKSPACE/.github/bootstrap.patch
           envsubst < $GITHUB_WORKSPACE/.github/bootstrap.patch &> $GITHUB_WORKSPACE/.github/bootstrap.patch
+          patch -d$HOME/bootstrap -p0 < $GITHUB_WORKSPACE/.github/bootstrap.patch
           cat $HOME/bootstrap/specs/config/repositories.yaml
 
       - name: Build with anod

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Bootstrap anod
         run: |
-          curl -L https://github.com/AdaCore/OpenUxAS-bootstrap/raw/master/install/bootstrap | bash -s -- --no-gnat
+          curl -L https://github.com/manthonyaiello/OpenUxAS-bootstrap/raw/master/util/bootstrap | BOOTSTRAP_FORK=manthonyaiello/OpenUxAS-bootstrap.git bash -s -- --no-gnat
+#      curl -L https://github.com/AdaCore/OpenUxAS-bootstrap/raw/master/install/bootstrap | bash -s -- --no-gnat
 
       - name: Patch bootstrap
         run: |

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -11,8 +11,6 @@ jobs:
         qualifier: [dev, scenario=gcov]
         python-version: [3.8]
     runs-on: ${{ matrix.os }}
-    env:
-      VPYTHON: $HOME/bootstrap/vpython/bin/python
     steps:
       - uses: actions/checkout@v2
 
@@ -32,10 +30,10 @@ jobs:
 
       - name: Build with anod
         run: |
-          SHELL=/bin/bash $VPYTHON $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+          SHELL=/bin/bash $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Run tests
         run: |
-          eval "$( $VPYTHON $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+          eval "$( $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
           echo $PATH
-          $VPYTHON $GITHUB_WORKSPACE/testsuite/run-tests
+          $HOME/bootstrap/vpython/bin/python $GITHUB_WORKSPACE/testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -18,17 +18,17 @@ jobs:
           repository: AdaCore/OpenUxAS-bootstrap
           path: bootstrap
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install anod dependencies
         run: |
           python -m pip install --upgrade pip
           pip install wheel zmq e3-core e3-testsuite
 
-      - name: Build Dependencies
+      - name: Build uxas dependencies with anod
         run: |
           bootstrap/anod -v build serial
           bootstrap/anod -v build pugixml
@@ -37,7 +37,7 @@ jobs:
           bootstrap/anod -v build zyre
           SHELL=/bin/bash bootstrap/anod -v build boost
 
-      - name: Upload Dependencies
+      - name: Upload uxas dependencies
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.python-version }}-bootstrap
@@ -57,11 +57,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download Dependencies
+      - name: Download uxas dependencies
         uses: actions/download-artifacts@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.python-version }}-bootstrap
           path: bootstrap
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install anod dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel zmq e3-core e3-testsuite
 
       - name: Build with anod
         run: bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04]
         component: [uxas]
         qualifier: [dev, scenario=gcov]
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -18,13 +18,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      # - name: Install anod dependencies
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install wheel 
-      #     pip install zmq e3-core e3-testsuite
-      #     sudo apt-get install -y uuid-dev
 
       - name: Bootstrap anod
         run: |
@@ -37,12 +30,10 @@ jobs:
 
       - name: Build with anod
         run: |
-          eval "$( $HOME/bootstrap/install/install-anod-venv --printenv )"
-          SHELL=/bin/bash $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+          SHELL=/bin/bash $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Run tests
         run: |
-          eval "$( $HOME/bootstrap/install/install-anod-venv --printenv )"
-          eval "$( $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+          eval "$( $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
           echo $PATH
           $GITHUB_WORKSPACE/testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: Build
 jobs:
-  deps:
+  dependencies:
     name: Build Dependencies
     strategy:
       fail-fast: true
@@ -35,7 +35,7 @@ jobs:
           bootstrap/anod -v build sqlite
           bootstrap/anod -v build lmcpgen
           bootstrap/anod -v build zyre
-          bootstrap/anod -v build boost
+          SHELL=/bin/bash bootstrap/anod -v build boost
 
       - name: Upload Dependencies
         uses: actions/upload-artifact@v2
@@ -45,6 +45,7 @@ jobs:
 
   build:
     name: Build UxAS
+    needs: dependencies
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: AdaCore/OpenUxAS-bootstrap
-          path: bootstrap
+          path: $HOME/bootstrap
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -34,21 +34,21 @@ jobs:
 
       - name: Bootstrap anod
         run: |
-          bootstrap/install/install-anod-venv -vv -y
+          $HOME/bootstrap/install/install-anod-venv -vv -y
 
       - name: Patch bootstrap
         run: |
-          patch -d~/bootstrap -p0 < ~/.github/bootstrap.patch
-          cat ~/bootstrap/specs/config/repositories.yaml
+          patch -d$HOME/bootstrap -p0 < $GITHUB_WORKSPACE/.github/bootstrap.patch
+          cat $HOME/bootstrap/specs/config/repositories.yaml
 
       - name: Build with anod
         run: |
-          eval "$( ~/bootstrap/install/install-anod-venv --printenv )"
-          SHELL=/bin/bash bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+          eval "$( $HOME/bootstrap/install/install-anod-venv --printenv )"
+          SHELL=/bin/bash $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Run tests
         run: |
-          eval "$( ~/bootstrap/install/install-anod-venv --printenv )"
-          eval "$( bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+          eval "$( $HOME/bootstrap/install/install-anod-venv --printenv )"
+          eval "$( $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
           echo $PATH
-          testsuite/run-tests
+          $GITHUB_WORKSPACE/testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -25,21 +25,30 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install anod dependencies
+      # - name: Install anod dependencies
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install wheel 
+      #     pip install zmq e3-core e3-testsuite
+      #     sudo apt-get install -y uuid-dev
+
+      - name: Bootstrap anod
         run: |
-          python -m pip install --upgrade pip
-          pip install wheel zmq e3-core e3-testsuite
-          sudo apt install -y uuid-dev
+          bootstrap/install/install-anod-venv -vv -y
+
+      - name: Patch bootstrap
+        run: |
+          patch -d~/bootstrap -p0 < ~/.github/bootstrap.patch
+          cat ~/bootstrap/specs/config/repositories.yaml
 
       - name: Build with anod
-        run: SHELL=/bin/bash bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
-      
-      - name: Set environment
         run: |
-          eval "$( bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
-          echo $PATH
+          eval "$( ~/bootstrap/install/install-anod-venv --printenv )"
+          SHELL=/bin/bash bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Run tests
         run: |
+          eval "$( ~/bootstrap/install/install-anod-venv --printenv )"
+          eval "$( bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
           echo $PATH
           testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -31,7 +31,7 @@ jobs:
           pip install wheel zmq e3-core e3-testsuite
 
       - name: Build with anod
-        run: bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+        run: SHELL=/bin/bash bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Set environment
         run: eval "$( bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -34,7 +34,11 @@ jobs:
         run: SHELL=/bin/bash bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Set environment
-        run: eval "$( bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+        run: |
+          eval "$( bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+          echo $PATH
       
       - name: Run tests
-        run: testsuite/run-tests
+        run: |
+          echo $PATH
+          testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -21,8 +21,7 @@ jobs:
 
       - name: Bootstrap anod
         run: |
-          curl -L https://github.com/manthonyaiello/OpenUxAS-bootstrap/raw/master/install/bootstrap | BOOTSTRAP_FORK=manthonyaiello/OpenUxAS-bootstrap.git bash -s -- --no-gnat
-#      curl -L https://github.com/AdaCore/OpenUxAS-bootstrap/raw/master/install/bootstrap | bash -s -- --no-gnat
+          curl -L https://github.com/AdaCore/OpenUxAS-bootstrap/raw/master/install/bootstrap | bash -s -- --no-gnat
 
       - name: Patch bootstrap
         run: |

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Patch bootstrap
         run: |
           patch -d$HOME/bootstrap -p0 < $GITHUB_WORKSPACE/.github/bootstrap.patch
+          envsubst < $GITHUB_WORKSPACE/.github/bootstrap.patch &> $GITHUB_WORKSPACE/.github/bootstrap.patch
           cat $HOME/bootstrap/specs/config/repositories.yaml
 
       - name: Build with anod

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -1,7 +1,50 @@
 on: [push, pull_request]
-name: Build UxAS
+name: Build
 jobs:
   build:
+    name: Build Dependencies
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        python-version: [3.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check out OpenUxAS-bootstrap
+        uses: actions/checkout@v2
+        with:
+          repository: AdaCore/OpenUxAS-bootstrap
+          path: bootstrap
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel zmq e3-core e3-testsuite
+
+      - name: Build Dependencies
+        run: |
+          bootstrap/anod -v build serial
+          bootstrap/anod -v build pugixml
+          bootstrap/anod -v build sqlite
+          bootstrap/anod -v build lmcpgen
+          bootstrap/anod -v build zyre
+          bootstrap/anod -v build boost
+
+      - name: Upload Dependencies
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.python-version }}-bootstrap
+          path: bootstrap
+
+  build:
+    name: Build UxAS
     strategy:
       fail-fast: false
       matrix:
@@ -10,24 +53,20 @@ jobs:
         qualifier: [dev, scenario=gcov]
         python-version: [3.8]
     runs-on: ${{ matrix.os }}
-    name: Build
     steps:
-      - name: Check out OpenUxAS-bootstrap
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+
+      - name: Download Dependencies
+        uses: actions/download-artifacts@v2
         with:
-          repository: AdaCore/OpenUxAS-bootstrap
+          name: ${{ matrix.os }}-${{ matrix.python-version }}-bootstrap
           path: bootstrap
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel zmq e3-core e3-testsuite
+
       - name: Build with anod
-        run: bootstrap/anod build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+        run: bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+      
       - name: Set environment
-        run: eval "$( bootstrap/anod printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+        run: eval "$( bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+      
       - name: Run tests
         run: testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -1,48 +1,6 @@
 on: [push, pull_request]
 name: Build
 jobs:
-  dependencies:
-    name: Build Dependencies
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
-        python-version: [3.8]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Check out OpenUxAS-bootstrap
-        uses: actions/checkout@v2
-        with:
-          repository: AdaCore/OpenUxAS-bootstrap
-          path: bootstrap
-
-      - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install anod dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel zmq e3-core e3-testsuite
-
-      - name: Build uxas dependencies with anod
-        run: |
-          bootstrap/anod -v build serial
-          bootstrap/anod -v build pugixml
-          bootstrap/anod -v build sqlite
-          bootstrap/anod -v build lmcpgen
-          bootstrap/anod -v build zyre
-          SHELL=/bin/bash bootstrap/anod -v build boost
-
-      - name: Upload uxas dependencies
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}-${{ matrix.python-version }}-bootstrap
-          path: bootstrap
-
   build:
     name: Build UxAS
     needs: dependencies
@@ -57,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download uxas dependencies
-        uses: actions/download-artifacts@v2
+      - name: Check out OpenUxAS-bootstrap
+        uses: actions/checkout@v2
         with:
-          name: ${{ matrix.os }}-${{ matrix.python-version }}-bootstrap
+          repository: AdaCore/OpenUxAS-bootstrap
           path: bootstrap
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -3,7 +3,6 @@ name: Build
 jobs:
   build:
     name: Build UxAS
-    needs: dependencies
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        component: [uxas]
+        component: [amase, uxas, uxas-ada]
         qualifier: [dev, scenario=gcov]
         python-version: [3.7, 3.8]
     runs-on: ${{ matrix.os }}
@@ -29,13 +29,26 @@ jobs:
           envsubst < $GITHUB_WORKSPACE/.github/bootstrap.patch &> $GITHUB_WORKSPACE/.github/bootstrap.patch
           patch -d$HOME/bootstrap -p0 < $GITHUB_WORKSPACE/.github/bootstrap.patch
 
+      - name: Install GNAT CE 2020
+        if: ${{ matrix.component == 'uxas-ada' }}
+        uses: ada-actions/toolchain@v0.2.0
+        with:
+          distrib: community        
+
       - name: Build with anod
         run: |
           SHELL=/bin/bash $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
-      - name: Run tests
+      - name: Run C++ tests
+        if: ${{ matrix.component == 'uxas' }}
         continue-on-error: ${{ matrix.qualifier == 'dev' }}
         run: |
           eval "$( $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
           echo $PATH
           $HOME/bootstrap/vpython/bin/python $GITHUB_WORKSPACE/testsuite/run-tests
+
+      - name: Run Ada tests
+        if: ${{ matrix.component == 'uxas-ada' }}
+        run: |
+          eval "$( $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --build-env )"
+          $HOME/bootstrap/vpython/bin/python $GITHUB_WORKSPACE/ada/arv-demo/testsuite/run-tests -E --timeout=1200

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04]
         component: [uxas]
         qualifier: [dev, scenario=gcov]
-        python-version: [3.8]
+        python-version: [3.7, 3.8]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -34,6 +34,7 @@ jobs:
           SHELL=/bin/bash $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Run tests
+        continue-on-error: ${{ matrix.qualifier == 'dev' }}
         run: |
           eval "$( $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
           echo $PATH

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -9,16 +9,10 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04]
         component: [uxas]
         qualifier: [dev, scenario=gcov]
-        python-version: [3.8]
+        python-version: [3.7, 3.8]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-
-      - name: Check out OpenUxAS-bootstrap
-        uses: actions/checkout@v2
-        with:
-          repository: AdaCore/OpenUxAS-bootstrap
-          path: $HOME/bootstrap
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -34,7 +28,7 @@ jobs:
 
       - name: Bootstrap anod
         run: |
-          $HOME/bootstrap/install/install-anod-venv -vv -y
+          curl -L https://github.com/AdaCore/OpenUxAS-bootstrap/raw/master/install/bootstrap | bash -s -- --no-gnat
 
       - name: Patch bootstrap
         run: |

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -11,6 +11,8 @@ jobs:
         qualifier: [dev, scenario=gcov]
         python-version: [3.8]
     runs-on: ${{ matrix.os }}
+    env:
+      VPYTHON: $HOME/bootstrap/vpython/bin/python
     steps:
       - uses: actions/checkout@v2
 
@@ -27,14 +29,13 @@ jobs:
         run: |
           envsubst < $GITHUB_WORKSPACE/.github/bootstrap.patch &> $GITHUB_WORKSPACE/.github/bootstrap.patch
           patch -d$HOME/bootstrap -p0 < $GITHUB_WORKSPACE/.github/bootstrap.patch
-          cat $HOME/bootstrap/specs/config/repositories.yaml
 
       - name: Build with anod
         run: |
-          SHELL=/bin/bash $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
+          SHELL=/bin/bash $VPYTHON $HOME/bootstrap/anod -v build ${{ matrix.component }} --qualifier=${{ matrix.qualifier}}
       
       - name: Run tests
         run: |
-          eval "$( $HOME/bootstrap/vpython/bin/python $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
+          eval "$( $VPYTHON $HOME/bootstrap/anod -v printenv ${{ matrix.component }} --qualifier=${{ matrix.qualifier }} )"
           echo $PATH
-          $GITHUB_WORKSPACE/testsuite/run-tests
+          $VPYTHON $GITHUB_WORKSPACE/testsuite/run-tests

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: Build
 jobs:
-  build:
+  deps:
     name: Build Dependencies
     strategy:
       fail-fast: true

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        component: [amase, uxas, uxas-ada]
+        component: [uxas-ada, uxas, amase]
         qualifier: [dev, scenario=gcov]
         python-version: [3.7, 3.8]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/uxas.yml
+++ b/.github/workflows/uxas.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Bootstrap anod
         run: |
-          curl -L https://github.com/manthonyaiello/OpenUxAS-bootstrap/raw/master/util/bootstrap | BOOTSTRAP_FORK=manthonyaiello/OpenUxAS-bootstrap.git bash -s -- --no-gnat
+          curl -L https://github.com/manthonyaiello/OpenUxAS-bootstrap/raw/master/install/bootstrap | BOOTSTRAP_FORK=manthonyaiello/OpenUxAS-bootstrap.git bash -s -- --no-gnat
 #      curl -L https://github.com/AdaCore/OpenUxAS-bootstrap/raw/master/install/bootstrap | bash -s -- --no-gnat
 
       - name: Patch bootstrap


### PR DESCRIPTION
Use github actions for continuous integration as a possible replacement for Travis. The current configuration runs a matrix with Ubuntu 18.04 and 20.04; python 3.7 and 3.8; amase, uxas, uxas-ada; dev and coverage.

A key feature of this configuration is that it runs the bootstrap bash script with minimal changes. GNAT CE is installed separately, to take advantage of AdaCore's github action for that; otherwise, the OpenUxAS-bootstrap process is used without modification to bootstrap the environment. We do still patch the repositories.yaml to use the checkout associated with the branch/pull request.

`continue-on-error` is set for running the test suite without coverage, as it currently fails when it tries to assemble the coverage results. This should be fixed in a separate commit, at which point we can remove that flag.